### PR TITLE
feat: add google sheets backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple menu application for "Crunch Time", a home-based food business operatin
 - React
 - TypeScript
 - React Router
-- Local Storage for data persistence
+- Google Sheets as backend storage
 - Progressive Web App (PWA) capabilities
 
 ## Getting Started
@@ -22,6 +22,7 @@ A simple menu application for "Crunch Time", a home-based food business operatin
 ### Prerequisites
 - Node.js (v14 or higher)
 - npm or yarn
+- Google service account with access to the `Menu_list` spreadsheet
 
 ### Installation
 1. Clone the repository
@@ -29,13 +30,26 @@ A simple menu application for "Crunch Time", a home-based food business operatin
    ```
    npm install
    ```
-3. Start the development server:
+3. Start the backend server:
+   ```
+   npm run server
+   ```
+4. In a separate terminal, start the frontend development server:
    ```
    npm start
    ```
-4. Open [http://localhost:3000](http://localhost:3000) to view the customer menu
-5. Open [http://localhost:3000/login](http://localhost:3000/login) to access the admin login page
-6. Enter the password: `crunchtime2023` to access the admin panel
+5. Open [http://localhost:3000](http://localhost:3000) to view the customer menu
+6. Open [http://localhost:3000/login](http://localhost:3000/login) to access the admin login page
+7. Enter the password: `crunchtime2023` to access the admin panel
+
+### Environment Variables
+
+The backend expects the following environment variables to be set:
+
+- `GOOGLE_SHEET_ID` – ID of the `Menu_list` spreadsheet
+- `GOOGLE_SERVICE_ACCOUNT` – JSON credentials for a service account with access to Google Sheets
+
+These can be added to a `.env` file or exported before starting the server.
 
 ## Usage
 
@@ -49,7 +63,7 @@ A simple menu application for "Crunch Time", a home-based food business operatin
 - Add, edit, and remove menu items
 - Mark items as available/unavailable
 - Manage party order options
-- All changes are automatically saved to local storage
+- All changes are synced with a Google Sheets backend
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -10,13 +10,17 @@
     "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "react-toastify": "^11.0.5",
-    "web-vitals": "^5.1.0"
+    "web-vitals": "^5.1.0",
+    "express": "^4.18.2",
+    "googleapis": "^136.0.0",
+    "cors": "^2.8.5"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "server": "node server/index.js"
   },
   "eslintConfig": {
     "extends": [

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,151 @@
+const express = require('express');
+const { google } = require('googleapis');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const SPREADSHEET_ID = process.env.GOOGLE_SHEET_ID;
+const SHEET_NAME = 'Curnch Time';
+
+async function getSheet() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT || '{}');
+  const auth = new google.auth.GoogleAuth({
+    credentials,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
+  const client = await auth.getClient();
+  return google.sheets({ version: 'v4', auth: client });
+}
+
+app.get('/api/menu', async (_req, res) => {
+  try {
+    const sheets = await getSheet();
+    const range = `${SHEET_NAME}!A2:H`;
+    const response = await sheets.spreadsheets.values.get({
+      spreadsheetId: SPREADSHEET_ID,
+      range,
+    });
+    const rows = response.data.values || [];
+    const items = rows.map((row) => ({
+      id: row[0],
+      name: row[1],
+      price: Number(row[2]),
+      unit: row[3],
+      category: row[4],
+      image: row[5],
+      description: row[6],
+      available: row[7] === 'available',
+    }));
+    res.json(items);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch menu' });
+  }
+});
+
+app.post('/api/menu', async (req, res) => {
+  try {
+    const item = req.body;
+    const sheets = await getSheet();
+    const values = [[
+      item.id,
+      item.name,
+      item.price,
+      item.unit,
+      item.category,
+      item.image,
+      item.description,
+      item.available ? 'available' : 'unavailable',
+    ]];
+    await sheets.spreadsheets.values.append({
+      spreadsheetId: SPREADSHEET_ID,
+      range: `${SHEET_NAME}!A:H`,
+      valueInputOption: 'USER_ENTERED',
+      resource: { values },
+    });
+    res.status(201).json({ message: 'Item added' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to add item' });
+  }
+});
+
+app.put('/api/menu/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const sheets = await getSheet();
+    const getResp = await sheets.spreadsheets.values.get({
+      spreadsheetId: SPREADSHEET_ID,
+      range: `${SHEET_NAME}!A2:H`,
+    });
+    const rows = getResp.data.values || [];
+    const rowIndex = rows.findIndex((r) => r[0] === id);
+    if (rowIndex === -1) {
+      return res.status(404).json({ error: 'Item not found' });
+    }
+    const rowNumber = rowIndex + 2; // account for header row
+    const item = req.body;
+    const values = [[
+      id,
+      item.name,
+      item.price,
+      item.unit,
+      item.category,
+      item.image,
+      item.description,
+      item.available ? 'available' : 'unavailable',
+    ]];
+    await sheets.spreadsheets.values.update({
+      spreadsheetId: SPREADSHEET_ID,
+      range: `${SHEET_NAME}!A${rowNumber}:H${rowNumber}`,
+      valueInputOption: 'USER_ENTERED',
+      resource: { values },
+    });
+    res.json({ message: 'Item updated' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to update item' });
+  }
+});
+
+app.delete('/api/menu/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const sheets = await getSheet();
+    const getResp = await sheets.spreadsheets.values.get({
+      spreadsheetId: SPREADSHEET_ID,
+      range: `${SHEET_NAME}!A2:H`,
+    });
+    const rows = getResp.data.values || [];
+    const rowIndex = rows.findIndex((r) => r[0] === id);
+    if (rowIndex === -1) {
+      return res.status(404).json({ error: 'Item not found' });
+    }
+    const requests = [{
+      deleteDimension: {
+        range: {
+          sheetId: 0,
+          dimension: 'ROWS',
+          startIndex: rowIndex + 1,
+          endIndex: rowIndex + 2,
+        },
+      },
+    }];
+    await sheets.spreadsheets.batchUpdate({
+      spreadsheetId: SPREADSHEET_ID,
+      resource: { requests },
+    });
+    res.json({ message: 'Item deleted' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to delete item' });
+  }
+});
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+

--- a/src/admin.tsx
+++ b/src/admin.tsx
@@ -8,8 +8,6 @@ import EditItemForm from './components/EditItemForm.tsx';
 import EditPartyOptionForm from './components/EditPartyOptionForm.tsx';
 import { Link } from 'react-router-dom';
 import { MenuItem, PartyOrderOption } from './types/menuTypes.ts';
-import { toast, ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
 
 export default function AdminPage() {
   const { 
@@ -23,20 +21,6 @@ export default function AdminPage() {
     updateMenuItem,
     updatePartyOption
   } = useMenu();
-  
-  // Function to explicitly save changes to localStorage
-  const saveChanges = () => {
-    localStorage.setItem('crunchTimeMenuItems', JSON.stringify(menuItems));
-    localStorage.setItem('crunchTimePartyOptions', JSON.stringify(partyOptions));
-    toast.success('Changes saved successfully!', {
-      position: "top-center",
-      autoClose: 3000,
-      hideProgressBar: false,
-      closeOnClick: true,
-      pauseOnHover: true,
-      draggable: true,
-    });
-  };
   
   const [activeTab, setActiveTab] = useState<'menu' | 'party'>('menu');
   const [editingItem, setEditingItem] = useState<MenuItem | null>(null);
@@ -61,7 +45,6 @@ export default function AdminPage() {
 
   return (
     <div style={{ maxWidth: 800, margin: '0 auto', padding: 16 }}>
-      <ToastContainer aria-label="Toast Notifications" />
       <header style={{ 
         marginBottom: 24, 
         display: 'flex', 
@@ -77,23 +60,6 @@ export default function AdminPage() {
           gap: 12,
           width: window.innerWidth < 480 ? '100%' : 'auto'
         }}>
-          <button
-            onClick={saveChanges}
-            style={{
-              textDecoration: 'none',
-              color: 'white',
-              padding: '8px 16px',
-              border: 'none',
-              borderRadius: 4,
-              fontSize: '0.9rem',
-              background: '#4caf50',
-              cursor: 'pointer',
-              fontWeight: 600,
-              width: window.innerWidth < 480 ? '100%' : 'auto'
-            }}
-          >
-            Save Changes
-          </button>
           <button
             onClick={() => {
               localStorage.removeItem('adminAuthenticated');


### PR DESCRIPTION
## Summary
- integrate Express server that connects to Google Sheets for menu CRUD operations
- update menu context to fetch and persist data through the new API
- simplify admin panel and document backend setup

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689b1a9a97b88320a3c3ea75c2c5225a