### PR TITLE
fix: allow configurable sheet name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The backend expects the following environment variables to be set:
 
 - `GOOGLE_SHEET_ID` – ID of the `Menu_list` spreadsheet
 - `GOOGLE_SERVICE_ACCOUNT` – JSON credentials for a service account with access to Google Sheets
+- `GOOGLE_SHEET_NAME` – Name of the sheet containing the menu data (defaults to `Crunch Time`)
 
 These can be added to a `.env` file or exported before starting the server.
 

--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,7 @@ app.use(cors());
 app.use(express.json());
 
 const SPREADSHEET_ID = process.env.GOOGLE_SHEET_ID;
-const SHEET_NAME = 'Curnch Time';
+const SHEET_NAME = process.env.GOOGLE_SHEET_NAME || 'Crunch Time';
 
 async function getSheet() {
   const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT || '{}');


### PR DESCRIPTION
## Summary
- allow menu API to read sheet tab name from `GOOGLE_SHEET_NAME`
- document new `GOOGLE_SHEET_NAME` env var in README

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_689c3e6ea5b4832090e4e7c1df0f7af0