### PR TITLE
Add serverless menu API for Vercel

### DIFF
--- a/api/_sheet.js
+++ b/api/_sheet.js
@@ -1,0 +1,16 @@
+const { google } = require('googleapis');
+
+const SPREADSHEET_ID = process.env.GOOGLE_SHEET_ID;
+const SHEET_NAME = process.env.GOOGLE_SHEET_NAME || 'Crunch Time';
+
+async function getSheet() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT || '{}');
+  const auth = new google.auth.GoogleAuth({
+    credentials,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
+  const client = await auth.getClient();
+  return google.sheets({ version: 'v4', auth: client });
+}
+
+module.exports = { SPREADSHEET_ID, SHEET_NAME, getSheet };

--- a/api/menu/[id].js
+++ b/api/menu/[id].js
@@ -1,0 +1,87 @@
+const { SPREADSHEET_ID, SHEET_NAME, getSheet } = require('../../_sheet');
+
+async function parseBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const data = Buffer.concat(chunks).toString();
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    return {};
+  }
+}
+
+module.exports = async (req, res) => {
+  const { id } = req.query;
+  if (req.method === 'PUT') {
+    try {
+      const sheets = await getSheet();
+      const getResp = await sheets.spreadsheets.values.get({
+        spreadsheetId: SPREADSHEET_ID,
+        range: `${SHEET_NAME}!A2:H`,
+      });
+      const rows = getResp.data.values || [];
+      const rowIndex = rows.findIndex((r) => r[0] === id);
+      if (rowIndex === -1) {
+        return res.status(404).json({ error: 'Item not found' });
+      }
+      const rowNumber = rowIndex + 2;
+      const item = await parseBody(req);
+      const values = [[
+        id,
+        item.name,
+        item.price,
+        item.unit,
+        item.category,
+        item.image,
+        item.description,
+        item.available ? 'available' : 'unavailable',
+      ]];
+      await sheets.spreadsheets.values.update({
+        spreadsheetId: SPREADSHEET_ID,
+        range: `${SHEET_NAME}!A${rowNumber}:H${rowNumber}`,
+        valueInputOption: 'USER_ENTERED',
+        resource: { values },
+      });
+      res.status(200).json({ message: 'Item updated' });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to update item' });
+    }
+  } else if (req.method === 'DELETE') {
+    try {
+      const sheets = await getSheet();
+      const getResp = await sheets.spreadsheets.values.get({
+        spreadsheetId: SPREADSHEET_ID,
+        range: `${SHEET_NAME}!A2:H`,
+      });
+      const rows = getResp.data.values || [];
+      const rowIndex = rows.findIndex((r) => r[0] === id);
+      if (rowIndex === -1) {
+        return res.status(404).json({ error: 'Item not found' });
+      }
+      const requests = [{
+        deleteDimension: {
+          range: {
+            sheetId: 0,
+            dimension: 'ROWS',
+            startIndex: rowIndex + 1,
+            endIndex: rowIndex + 2,
+          },
+        },
+      }];
+      await sheets.spreadsheets.batchUpdate({
+        spreadsheetId: SPREADSHEET_ID,
+        resource: { requests },
+      });
+      res.status(200).json({ message: 'Item deleted' });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to delete item' });
+    }
+  } else {
+    res.status(405).json({ error: 'Method not allowed' });
+  }
+};

--- a/api/menu/index.js
+++ b/api/menu/index.js
@@ -1,0 +1,69 @@
+const { SPREADSHEET_ID, SHEET_NAME, getSheet } = require('../_sheet');
+
+async function parseBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const data = Buffer.concat(chunks).toString();
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    return {};
+  }
+}
+
+module.exports = async (req, res) => {
+  if (req.method === 'GET') {
+    try {
+      const sheets = await getSheet();
+      const range = `${SHEET_NAME}!A2:H`;
+      const response = await sheets.spreadsheets.values.get({
+        spreadsheetId: SPREADSHEET_ID,
+        range,
+      });
+      const rows = response.data.values || [];
+      const items = rows.map((row) => ({
+        id: row[0],
+        name: row[1],
+        price: Number(row[2]),
+        unit: row[3],
+        category: row[4],
+        image: row[5],
+        description: row[6],
+        available: row[7] === 'available',
+      }));
+      res.status(200).json(items);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to fetch menu' });
+    }
+  } else if (req.method === 'POST') {
+    try {
+      const item = await parseBody(req);
+      const sheets = await getSheet();
+      const values = [[
+        item.id,
+        item.name,
+        item.price,
+        item.unit,
+        item.category,
+        item.image,
+        item.description,
+        item.available ? 'available' : 'unavailable',
+      ]];
+      await sheets.spreadsheets.values.append({
+        spreadsheetId: SPREADSHEET_ID,
+        range: `${SHEET_NAME}!A:H`,
+        valueInputOption: 'USER_ENTERED',
+        resource: { values },
+      });
+      res.status(201).json({ message: 'Item added' });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to add item' });
+    }
+  } else {
+    res.status(405).json({ error: 'Method not allowed' });
+  }
+};

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,10 @@
       "src": "package.json",
       "use": "@vercel/static-build",
       "config": { "distDir": "build" }
+    },
+    {
+      "src": "api/**/*.js",
+      "use": "@vercel/node"
     }
   ],
   "routes": [


### PR DESCRIPTION
## Summary
- add Google Sheets helper and new serverless functions for menu API
- include PUT/DELETE handlers and request body parsing
- configure Vercel build to bundle API functions

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_689c489601d883208bedddc721c21563